### PR TITLE
Use a CMD instead of an ENTRYPOINT to run the web container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN pip install -r /code/requirements-dev.txt
 RUN cd /usr/local/lib/python3.7/site-packages && python /code/setup.py develop
 
 COPY ./scripts/web-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/entrypoint.sh"]


### PR DESCRIPTION
This allows the command to be easily overwritten when debugging.