### PR TITLE
Allow fake emails in tracker mailchimp request

### DIFF
--- a/tracker/tasks.py
+++ b/tracker/tasks.py
@@ -16,6 +16,13 @@ def add_mailchimp_subscriber(email):
         json={'email_address': email, 'status': 'subscribed', 'tags': ['stade']},
     )
 
-    if not r.ok and r.json()['title'] != 'Member Exists':
+    # MailChimp API doesn't return special status codes for members already existing, or fake
+    # emails So ignore them (since there's nothing we can really do) and only raise in the case of
+    # a different, more legitimate error.
+    if (
+        not r.ok
+        and r.json()['title'] != 'Member Exists'
+        and 'looks fake or invalid' not in r.json()['detail']
+    ):
         logger.error(r.text)
         r.raise_for_status()


### PR DESCRIPTION
Resolves multiple sentry issues, responses look like:
```
{
  "type": "http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/",
  "title": "Invalid Resource",
  "status": 400,
  "detail": "test@test.com looks fake or invalid, please enter a real email address.",
  "instance": "6a8e8c13-2e26-4d98-ae0a-49c75b5f6966"
}
```
