### PR TITLE
Pin mypy to 0.720 to avoid issue with mypy_django_plugin

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ basepython = python3
 skipsdist = true
 skip_install = true
 deps =
-    mypy
+    mypy==0.720
     django-stubs
     djangorestframework-stubs
     -r requirements.txt


### PR DESCRIPTION
FYI @brianhelba, nightlies are failing with the following error:
```
error: Error importing plugin 'mypy_django_plugin.main'
```

related: https://github.com/typeddjango/django-stubs/issues/166, https://github.com/typeddjango/django-stubs/issues/160. 
