### PR TITLE
Don't overwrite existing S3Boto3Storage config

### DIFF
--- a/stade/core/storage_backends.py
+++ b/stade/core/storage_backends.py
@@ -5,4 +5,9 @@ from storages.backends.s3boto3 import S3Boto3Storage
 class TimeoutS3Boto3Storage(S3Boto3Storage):
     """Override boto3 default timeout values."""
 
-    config = Config(connect_timeout=3, read_timeout=10, retries={'max_attempts': 5})
+    def __init__(self, **settings):
+        super().__init__(**settings)
+
+        self.config = self.config.merge(
+            Config(connect_timeout=3, read_timeout=10, retries={'max_attempts': 5})
+        )


### PR DESCRIPTION
The existing config contains the critical option `signature_version`. So, just update the existing working configuration, adding timeout options.