### PR TITLE
Remove broken google analytics

### DIFF
--- a/stade/core/templates/data.html
+++ b/stade/core/templates/data.html
@@ -31,27 +31,27 @@
         <tr>
           <th>1</th>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part1_Training_Data.zip">
               Download (602MB)</a><br>
             900 dermoscopic lesion images in
             JPEG format, with EXIF data stripped.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part1_Training_GroundTruth.zip">
               Download (6MB)</a><br>
             900 binary mask images in PNG format.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part1_Test_Data.zip">
               Download (232MB)</a><br>
             379 images of the exact same format as
             the Training Data.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part1_Test_GroundTruth.zip">
               Download (2MB)</a><br>
           </td>
@@ -64,7 +64,7 @@
         <tr>
           <th>2</th>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part2_Training_Data.zip">
               Download (671MB)</a><br>
             807 lesion images in JPEG format
@@ -72,14 +72,14 @@
             with EXIF data stripped.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part2_Training_GroundTruth.zip">
               Download (5MB)</a><br>
             807 dermoscopic feature files in
             JSON format.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part2_Test_Data.zip">
               Download (257MB)</a><br>
             335 lesion images and 335 corresponding
@@ -87,7 +87,7 @@
             Training Data.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part2_Test_GroundTruth.zip">
               Download (2MB)</a><br>
           </td>
@@ -95,27 +95,27 @@
         <tr>
           <th>2B</th>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part2B_Training_Data.zip">
               Download (565MB)</a><br>
             807 lesion images in JPEG
             format, with EXIF data stripped.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part2B_Training_GroundTruth.zip">
               Download (5MB)</a><br>
             1614 binary mask images in PNG format.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part2B_Test_Data.zip">
               Download (216MB)</a><br>
             335 lesion images of the exact same
             formats as the Training Data.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part2B_Test_GroundTruth.zip">
               Download (2MB)</a><br>
           </td>
@@ -123,26 +123,26 @@
         <tr>
           <th>3</th>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part3_Training_Data.zip">
               Download (602MB)</a><br>
             900 dermoscopic lesion images in JPEG format.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part3_Training_GroundTruth.csv">
               Download (19KB)</a><br>
             900 entries of gold standard malignant status.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part3_Test_Data.zip">
               Download (232MB)</a><br>
             379 images of the exact same format as
             the Training Data.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part3_Test_GroundTruth.csv">
               Download (7KB)</a><br>
           </td>
@@ -150,7 +150,7 @@
         <tr>
           <th>3B</th>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part3B_Training_Data.zip">
               Download (608MB)</a><br>
             900 dermoscopic lesion images in
@@ -158,13 +158,13 @@
             masks in PNG format.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part3B_Training_GroundTruth.csv">
               Download (19KB)</a><br>
             900 entries of gold standard malignant status.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part3B_Test_Data.zip">
               Download (234MB)</a><br>
             379 images and 379 associated
@@ -172,7 +172,7 @@
             Training Data.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2016/ISBI2016_ISIC_Part3B_Test_GroundTruth.csv">
               Download (7KB)</a><br>
           </td>
@@ -209,7 +209,7 @@
         <tr>
           <th>1</th>
           <td rowspan="3">
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2017/ISIC-2017_Training_Data.zip">
               Download (5.8GB)</a><br>
             2000 lesion images in JPEG
@@ -217,19 +217,19 @@
             format, with EXIF data stripped.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2017/ISIC-2017_Training_Part1_GroundTruth.zip">
               Download (9MB)</a><br>
             2000 binary mask images in PNG
             format.
           </td>
           <td rowspan="3">
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2017/ISIC-2017_Test_v2_Data.zip">
               Download (5.4GB)</a>
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2017/ISIC-2017_Test_v2_Part1_GroundTruth.zip">
               Download (18MB)</a>
           </td>
@@ -242,13 +242,13 @@
         <tr>
           <th>2</th>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2017/ISIC-2017_Training_Part2_GroundTruth.zip">
               Download (710KB)</a><br>
             2000 dermoscopic feature files in JSON format.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2017/ISIC-2017_Test_v2_Part2_GroundTruth.zip">
               Download (210KB)</a><br>
           </td>
@@ -256,13 +256,13 @@
         <tr>
           <th>3</th>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2017/ISIC-2017_Training_Part3_GroundTruth.csv">
               Download (43KB)</a><br>
             2000 entries of gold standard lesion diagnoses.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2017/ISIC-2017_Test_v2_Part3_GroundTruth.csv">
               Download (13KB)</a><br>
           </td>
@@ -299,18 +299,18 @@
         <tr>
           <th>1</th>
           <td rowspan="2">
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2018/ISIC2018_Task1-2_Training_Input.zip">
               Download (10.4GB)</a><br>
             2594 images and 12970 corresponding ground truth response masks (5 for each image).
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2018/ISIC2018_Task1_Training_GroundTruth.zip">
               Download (26MB)</a><br>
           </td>
           <td rowspan="2">
-            <a class="track-outbound"
+            <a 
                href="https://isic-challenge-data.s3.amazonaws.com/2018/ISIC2018_Task1-2_Test_Input.zip">Download
               (2.2GB)</a><br/>
             1000 images.
@@ -325,7 +325,7 @@
         <tr>
           <th>2</th>
           <td>
-            <a class="track-outbound"
+            <a 
                href="https://isic-challenge-data.s3.amazonaws.com/2018/ISIC2018_Task2_Training_GroundTruth_v3.zip">Download
               (33MB)</a><br>
           </td>
@@ -334,19 +334,19 @@
         <tr>
           <th>3</th>
           <td>
-            <a class="track-outbound"
+            <a 
                href="https://isic-challenge-data.s3.amazonaws.com/2018/ISIC2018_Task3_Training_Input.zip">Download
               (2.6GB)</a><br>
             10015 images and 1 ground truth response CSV file (containing 1 header row and 10015
             corresponding response rows).
           </td>
           <td>
-            <a class="track-outbound"
+            <a 
                href="https://isic-challenge-data.s3.amazonaws.com/2018/ISIC2018_Task3_Training_GroundTruth.zip">Download
               (36KB)</a><br>
           </td>
           <td>
-            <a class="track-outbound"
+            <a 
                href="https://isic-challenge-data.s3.amazonaws.com/2018/ISIC2018_Task3_Test_Input.zip">Download
               (401MB)</a><br>
             1512 images.
@@ -393,19 +393,19 @@
         <tr>
           <th>1</th>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2019/ISIC_2019_Training_Input.zip">
               Download (9.1GB)</a><br>
             25,331 JPEG images of skin lesions.
           </td>
           <td rowspan="2">
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2019/ISIC_2019_Training_GroundTruth.csv">
               Download (1MB)</a><br>
             25,331 entries of gold standard lesion diagnoses.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2019/ISIC_2019_Test_Input.zip">
               Download (3.6GB)</a><br>
             8,238 JPEG images of skin lesions.
@@ -419,14 +419,14 @@
         <tr>
           <th>2</th>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2019/ISIC_2019_Training_Metadata.csv">
               Download (1MB)</a><br>
             25,331 metadata entries of age, sex, general anatomic site, and common lesion
             identifier.
           </td>
           <td>
-            <a class="track-outbound" href=
+            <a href=
                 "https://isic-challenge-data.s3.amazonaws.com/2019/ISIC_2019_Test_Metadata.csv">
               Download (287KB)</a><br>
             8,238 metadata entries of age, sex, and general anatomic site.
@@ -487,43 +487,43 @@
         <tbody>
         <tr>
           <td>
-            <a class="track-outbound" href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_Dicom.zip">Download DICOM (48.9GB)</a>
+            <a href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_Dicom.zip">Download DICOM (48.9GB)</a>
             <br>
             33,126 DICOM images with embedded metadata.
             <br>
             <hr>
-            <a class="track-outbound" href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_JPEG.zip">Download JPEG (23GB)</a>
+            <a href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_JPEG.zip">Download JPEG (23GB)</a>
             <br>
             33,126 JPEG images.
             <br>
-            <a class="track-outbound" href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_GroundTruth.csv">Download metadata (2MB)</a>
+            <a href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_GroundTruth.csv">Download metadata (2MB)</a>
             <br>
             33,126 metadata entries of patient ID, sex, age, and general anatomic site.
             <br />
-            <a class="track-outbound" href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_GroundTruth_v2.csv">Download metadata v2 (2MB)</a>
+            <a href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_GroundTruth_v2.csv">Download metadata v2 (2MB)</a>
             <br>
             33,126 metadata entries of patient ID, lesion ID, sex, age, and general anatomic site.
             <br />
-            <a class="track-outbound" href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_Duplicates.csv">Download duplicate image list (2MB)</a>
+            <a href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_Duplicates.csv">Download duplicate image list (2MB)</a>
             <br>
             List of 425 duplicate images.
           </td>
-          <td><a class="track-outbound" href=
+          <td><a href=
               "https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Training_GroundTruth.csv">
             Download (2MB)</a><br>
             33,126 entries of gold standard lesion diagnoses.
           </td>
           <td>
-            <a class="track-outbound" href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Test_Dicom.zip">Download DICOM (15.3GB)</a>
+            <a href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Test_Dicom.zip">Download DICOM (15.3GB)</a>
             <br>
             10,982 DICOM images with embedded metadata.
             <br>
             <hr>
-            <a class="track-outbound" href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Test_JPEG.zip">Download JPEG (6.7GB)</a>
+            <a href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Test_JPEG.zip">Download JPEG (6.7GB)</a>
             <br>
             10,982 JPEG images.
             <br>
-            <a class="track-outbound" href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Test_Metadata.csv">Download metadata (458KB)</a>
+            <a href="https://isic-challenge-data.s3.amazonaws.com/2020/ISIC_2020_Test_Metadata.csv">Download metadata (458KB)</a>
             <br>
             10,982 metadata entries of patient ID, sex, age, and general anatomic site.
           </td>


### PR DESCRIPTION
This breaks even conservative ad blockers. Figure out how to properly do google analytics in the future, but let the download page work for now.