### PR TITLE
Ensure that all transitive requirements are installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if readme_file.exists():
     with readme_file.open() as f:
         long_description = f.read()
 else:
-    # WHen this is first installed in development Docker, README.md is not available
+    # When this is first installed in development Docker, README.md is not available
     long_description = ''
 
 setup(
@@ -36,14 +36,13 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        # 'boto3',
         'celery',
         'dictdiffer',
         'django',
         'django-admin-display',
         'django-allauth',
         'django-composed-configuration[dev,prod]>=0.10.0',
-        'django-configurations',
+        'django-configurations[database,email]',
         'django-extensions',
         'django-filter',
         'django-girder-utils',


### PR DESCRIPTION
The old pip resolver does not properly fetch transitive requirements in certain cases. Until the new pip resolver is available more consistently, this works around the bug.