### PR TITLE
Ensure local templates are still loaded first

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'django',
         'django-admin-display',
         'django-allauth',
-        'django-composed-configuration[dev,prod]>=0.10.0',
+        'django-composed-configuration[dev,prod]>=0.12.0',
         'django-configurations[database,email]',
         'django-extensions',
         'django-filter',

--- a/stade/settings.py
+++ b/stade/settings.py
@@ -21,11 +21,9 @@ class StadeMixin(ConfigMixin):
 
     @staticmethod
     def before_binding(configuration: ComposedConfiguration) -> None:
-        # Insert before other apps with allauth templates
-        auth_app_index = configuration.INSTALLED_APPS.index(
-            'composed_configuration.authentication.apps.AuthenticationConfig'
-        )
-        configuration.INSTALLED_APPS.insert(auth_app_index, 'stade.core.apps.CoreConfig')
+        # Insert before other apps with styled templates
+        style_app_index = configuration.INSTALLED_APPS.index('girder_style')
+        configuration.INSTALLED_APPS.insert(style_app_index, 'stade.core.apps.CoreConfig')
 
         admin_index = configuration.INSTALLED_APPS.index('django.contrib.admin')
         configuration.INSTALLED_APPS.insert(admin_index, 'jazzmin')


### PR DESCRIPTION
This adds support for the latest release of `django-composed-configuration`.