### PR TITLE
Use DRF permissions, not authentication, to allow any user

### DIFF
--- a/stade/core/rest/views.py
+++ b/stade/core/rest/views.py
@@ -2,8 +2,7 @@ import logging
 
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.decorators import api_view, authentication_classes
+from rest_framework.decorators import api_view
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 
@@ -22,7 +21,6 @@ def challenge_detail(request, challenge_id):
 
 
 @api_view(['GET'])
-@authentication_classes([SessionAuthentication])
 def leaderboard(request, task_id, cluster):
     if request.user.is_staff:
         task = get_object_or_404(Task, pk=task_id)
@@ -52,7 +50,6 @@ def leaderboard(request, task_id, cluster):
 
 
 @api_view(['GET'])
-@authentication_classes([SessionAuthentication])
 def submission_scores(request, submission_id):
     if request.user.is_staff:
         # Remove all deferred fields, since we want the score immediately

--- a/stade/tracker/rest/email.py
+++ b/stade/tracker/rest/email.py
@@ -1,11 +1,9 @@
-from typing import List, Type
-
 from django.utils.encoding import force_str
 from rest_framework import serializers, status, viewsets
-from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import APIException
 from rest_framework.fields import EmailField
 from rest_framework.mixins import CreateModelMixin
+from rest_framework.permissions import AllowAny
 
 from stade.tracker.models import Email
 
@@ -38,7 +36,7 @@ class EmailSerializer(serializers.ModelSerializer):
 
 class EmailCreateViewSet(CreateModelMixin, viewsets.GenericViewSet):
     # no auth required for tracking emails
-    authentication_classes: List[Type[BaseAuthentication]] = []
+    permission_classes = [AllowAny]
 
     queryset = Email.objects.all()
     serializer_class = EmailSerializer


### PR DESCRIPTION
The default permission classes is `[IsAuthenticatedOrReadOnly]`. Non-read-only endpoints must override this to allow anonymous access. Read-only endpoints do not require any overrides.